### PR TITLE
fix(openproject): change authentication from Bearer to Basic auth

### DIFF
--- a/ai-workspace/api-responses/test-project-openproject-response.json
+++ b/ai-workspace/api-responses/test-project-openproject-response.json
@@ -1,0 +1,89 @@
+{
+  "_embedded": {
+    "status": {
+      "_type": "ProjectStatus",
+      "id": "on_track",
+      "name": "On track",
+      "_links": {
+        "self": {
+          "href": "/api/v3/project_statuses/on_track",
+          "title": "On track"
+        }
+      }
+    }
+  },
+  "_type": "Project",
+  "id": 1,
+  "identifier": "test-project",
+  "name": "Test Project",
+  "active": true,
+  "public": false,
+  "description": {
+    "format": "markdown",
+    "raw": "",
+    "html": ""
+  },
+  "createdAt": "2025-09-24T06:42:21.401Z",
+  "updatedAt": "2025-09-24T06:49:55.446Z",
+  "statusExplanation": {
+    "format": "markdown",
+    "raw": "",
+    "html": ""
+  },
+  "_links": {
+    "self": {
+      "href": "/api/v3/projects/1",
+      "title": "Test Project"
+    },
+    "createWorkPackage": {
+      "href": "/api/v3/projects/1/work_packages/form",
+      "method": "post"
+    },
+    "createWorkPackageImmediately": {
+      "href": "/api/v3/projects/1/work_packages",
+      "method": "post"
+    },
+    "workPackages": {
+      "href": "/api/v3/projects/1/work_packages"
+    },
+    "storages": [],
+    "categories": {
+      "href": "/api/v3/projects/1/categories"
+    },
+    "versions": {
+      "href": "/api/v3/projects/1/versions"
+    },
+    "memberships": {
+      "href": "/api/v3/memberships?filters=%5B%7B%22project%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D"
+    },
+    "types": {
+      "href": "/api/v3/projects/1/types"
+    },
+    "update": {
+      "href": "/api/v3/projects/1/form",
+      "method": "post"
+    },
+    "updateImmediately": {
+      "href": "/api/v3/projects/1",
+      "method": "patch"
+    },
+    "delete": {
+      "href": "/api/v3/projects/1",
+      "method": "delete"
+    },
+    "schema": {
+      "href": "/api/v3/projects/schema"
+    },
+    "status": {
+      "href": "/api/v3/project_statuses/on_track",
+      "title": "On track"
+    },
+    "ancestors": [],
+    "projectStorages": {
+      "href": "/api/v3/project_storages?filters=%5B%7B%22projectId%22%3A%7B%22operator%22%3A%22%3D%22%2C%22values%22%3A%5B%221%22%5D%7D%7D%5D"
+    },
+    "parent": {
+      "href": null
+    }
+  }
+}

--- a/ai-workspace/completion-reports/issue-7-openproject-project-endpoint-completion-report.md
+++ b/ai-workspace/completion-reports/issue-7-openproject-project-endpoint-completion-report.md
@@ -93,11 +93,31 @@ Successfully implemented a new API endpoint that fetches project information fro
 - **Response Format**: Standardized success/error response structure
 - **Error Codes**: Documented all custom error codes and their meanings
 
+## Authentication Fix Applied
+
+### Issue Identified
+- **Problem**: Initial implementation used `Authorization: Bearer <token>` for OpenProject API authentication
+- **Root Cause**: OpenProject API documentation specifies that UI-generated API keys must use Basic Authentication
+- **Error**: OpenProject was returning "You did not provide the correct credentials" for Bearer token requests
+
+### Solution Implemented
+- **Authentication Method**: Changed from Bearer to Basic Authentication
+- **Format**: `Authorization: Basic base64('apikey:' + API_TOKEN)`
+- **Code Change**: Updated `openprojectService.ts` to use `Buffer.from(\`apikey:${this.apiToken}\`).toString('base64')`
+- **Verification**: Successfully tested with curl command: `curl -u apikey:$API_KEY http://localhost:8082/api/v3/projects/test-project`
+
+### Real API Response Captured
+- **File**: `ai-workspace/api-responses/test-project-openproject-response.json`
+- **Source**: Live OpenProject instance running in Docker
+- **Project**: `test-project` (ID: 1)
+- **Data**: Complete OpenProject v3 API response with HAL+JSON format including project metadata, status, and HATEOAS links
+
 ## Next Steps
 
 ### Immediate Follow-ups
-- **API Token Setup**: Developers need to generate OpenProject API tokens for testing
-- **Integration Testing**: Test with actual OpenProject instance in docker-compose stack
+- ✅ **Authentication Fixed**: OpenProject API now works with proper Basic auth
+- ✅ **Real Data Captured**: Actual API response saved for reference
+- **Integration Testing**: Verify end-to-end API flow works in production
 - **Performance Monitoring**: Consider adding request timeout configuration
 
 ### Future Enhancements
@@ -109,7 +129,7 @@ Successfully implemented a new API endpoint that fetches project information fro
 ## Links
 - **GitHub Issue**: [#7](https://github.com/leeray75/content-automation-api/issues/7)
 - **Feature Branch**: `feature/issue-7-openproject-project-endpoint`
-- **Commit**: `28b29a7` - feat(openproject): implement OpenProject project endpoint
+- **API Response Sample**: `ai-workspace/api-responses/test-project-openproject-response.json`
 
 ## Acceptance Criteria Status
 - ✅ New endpoint returns valid project data from OpenProject

--- a/src/services/openprojectService.ts
+++ b/src/services/openprojectService.ts
@@ -39,10 +39,13 @@ export class OpenProjectService {
     logger.info(`Fetching OpenProject project: ${projectId}`, { url });
 
     try {
+      // OpenProject API keys use Basic auth with username "apikey" and the token as password
+      const auth = Buffer.from(`apikey:${this.apiToken}`).toString('base64');
+      
       const response = await fetch(url, {
         method: 'GET',
         headers: {
-          'Authorization': `Bearer ${this.apiToken}`,
+          'Authorization': `Basic ${auth}`,
           'Accept': 'application/json',
           'Content-Type': 'application/json',
         },


### PR DESCRIPTION
- Updated OpenProjectService to use Basic auth with 'apikey' username
- Fixed authentication issue with OpenProject API tokens
- Added real API response sample for test-project
- Updated completion report with authentication fix details

Resolves authentication error: 'You did not provide the correct credentials'